### PR TITLE
Feat/daily staking global totalrewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "codegen-new-mech-fees-base": "graph codegen subgraphs/new-mech-fees/mech-fees-base/subgraph.yaml -o subgraphs/new-mech-fees/common/generated",
     "codegen-predict": "graph codegen subgraphs/predict/subgraph.yaml",
     "codegen-governance": "graph codegen subgraphs/governance/subgraph.yaml",
-    "codegen-staking": "graph codegen subgraphs/staking/subgraph.gnosis.yaml",
+    "codegen-staking": "graph codegen subgraphs/staking/subgraph.gnosis.yaml --output-dir subgraphs/staking/generated",
     "codegen-liquidity-eth": "graph codegen subgraphs/liquidity/liquidity-eth/subgraph.yaml -o subgraphs/liquidity/liquidity-eth/generated",
     "codegen-babydegen-optimism": "graph codegen subgraphs/babydegen/babydegen-optimism/subgraph.yaml",
     "build-tokenomics:ethereum": "yarn codegen-tokenomics-l2 && yarn codegen-tokenomics-l1 && cp -r generated subgraphs/tokenomics/tokenomics-eth/ && graph build subgraphs/tokenomics/tokenomics-eth/subgraph.yaml",

--- a/subgraphs/staking/schema.graphql
+++ b/subgraphs/staking/schema.graphql
@@ -195,3 +195,10 @@ type Global @entity(immutable: false) {
   currentOlasStaked: BigInt!
   totalRewards: BigInt!
 }
+
+type DailyStakingGlobal @entity(immutable: false) {
+  id: Bytes!
+  timestamp: BigInt!
+  block: BigInt!
+  totalRewards: BigInt!
+}

--- a/subgraphs/staking/src/staking-factory.ts
+++ b/subgraphs/staking/src/staking-factory.ts
@@ -4,7 +4,7 @@ import {
   InstanceStatusChanged as InstanceStatusChangedEvent,
   OwnerUpdated as OwnerUpdatedEvent,
   VerifierUpdated as VerifierUpdatedEvent
-} from "../generated/StakingFactory/StakingFactory"
+} from "../../../generated/StakingFactory/StakingFactory"
 import {
   InstanceCreated,
   InstanceRemoved,
@@ -12,9 +12,9 @@ import {
   OwnerUpdated,
   VerifierUpdated,
   StakingContract
-} from "../generated/schema"
-import { StakingProxy } from "../generated/templates";
-import { StakingProxy as StakingProxyContract } from "../generated/templates/StakingProxy/StakingProxy";
+} from "../../../generated/schema"
+import { StakingProxy } from "../../../generated/templates";
+import { StakingProxy as StakingProxyContract } from "../../../generated/templates/StakingProxy/StakingProxy";
 
 export function handleInstanceCreated(event: InstanceCreatedEvent): void {
   StakingProxy.create(event.params.instance);

--- a/subgraphs/staking/src/staking-proxy.ts
+++ b/subgraphs/staking/src/staking-proxy.ts
@@ -9,7 +9,7 @@ import {
   ServiceUnstaked as ServiceUnstakedEvent,
   ServicesEvicted as ServicesEvictedEvent,
   Withdraw as WithdrawEvent,
-} from "../generated/templates/StakingProxy/StakingProxy"
+} from "../../../generated/templates/StakingProxy/StakingProxy"
 import {
   Checkpoint,
   Deposit,
@@ -21,8 +21,8 @@ import {
   ServiceUnstaked,
   ServicesEvicted,
   Withdraw
-} from "../generated/schema"
-import { createRewardUpdate, getGlobal, getOlasForStaking } from "./utils"
+} from "../../../generated/schema"
+import { createRewardUpdate, getGlobal, getOlasForStaking, dayStart, upsertDailyStakingGlobal } from "./utils"
 
 export function handleCheckpoint(event: CheckpointEvent): void {
   let entity = new Checkpoint(
@@ -54,6 +54,15 @@ export function handleCheckpoint(event: CheckpointEvent): void {
       service.save();
     }
   }
+
+  // Update global cumulative staking rewards
+  let global = getGlobal();
+  global.totalRewards = global.totalRewards.plus(totalRewards);
+  global.save();
+
+  // Upsert daily snapshot with latest totals
+  const dayTimestamp = dayStart(event.block.timestamp);
+  upsertDailyStakingGlobal(dayTimestamp, event.block.number, global.totalRewards);
 
   // Update claimable staking rewards
   createRewardUpdate(

--- a/subgraphs/staking/src/utils.ts
+++ b/subgraphs/staking/src/utils.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
-import { Global, RewardUpdate } from "../generated/schema";
-import { StakingProxy as StakingProxyContract } from "../generated/templates/StakingProxy/StakingProxy";
+import { Global, RewardUpdate, DailyStakingGlobal } from "../../../generated/schema";
+import { StakingProxy as StakingProxyContract } from "../../../generated/templates/StakingProxy/StakingProxy";
 
 export function createRewardUpdate(
   id: string,
@@ -36,6 +36,25 @@ export function getGlobal(): Global {
     global.cumulativeOlasStaked = BigInt.fromI32(0);
     global.cumulativeOlasUnstaked = BigInt.fromI32(0);
     global.currentOlasStaked = BigInt.fromI32(0);
+    global.totalRewards = BigInt.fromI32(0);
   }
   return global;
+}
+
+const ONE_DAY = BigInt.fromI32(86400);
+
+export function dayStart(timestamp: BigInt): BigInt {
+  return timestamp.div(ONE_DAY).times(ONE_DAY);
+}
+
+export function upsertDailyStakingGlobal(dayTimestamp: BigInt, block: BigInt, totalRewards: BigInt): void {
+  const id = Bytes.fromUTF8(dayTimestamp.toString());
+  let snapshot = DailyStakingGlobal.load(id);
+  if (snapshot == null) {
+    snapshot = new DailyStakingGlobal(id);
+    snapshot.timestamp = dayTimestamp;
+  }
+  snapshot.block = block;
+  snapshot.totalRewards = totalRewards;
+  snapshot.save();
 }


### PR DESCRIPTION
For BabyDegen Subgraph metrics we need , rewards till a date (cumulative rewards earned by agents till that day) - we need it for last 7 days

- Track global.totalRewards per checkpoint and persist a DailyStakingGlobal record at day start.
- Added helpers dayStart and upsertDailyStakingGlobal to keep logic clean.
- Updated codegen-staking to emit bindings under subgraphs/staking/generated.